### PR TITLE
Add plain to list-units

### DIFF
--- a/helm-systemd.el
+++ b/helm-systemd.el
@@ -64,7 +64,7 @@
 (add-to-list 'auto-mode-alist `(, (concat (regexp-quote helm-systemd-buffer-name) "\\'") . helm-systemd-status-mode))
 
 (defun helm-systemd-command-line-option ()
-  (concat "--no-pager --no-legend -t " (car helm-systemd-command-types) (if helm-systemd-list-all " --all")))
+  (concat "--no-pager --no-legend --plain -t " (car helm-systemd-command-types) (if helm-systemd-list-all " --all")))
 
 (defvar helm-systemd-map
   (let ((map (make-sparse-keymap)))


### PR DESCRIPTION
prevent adding 'dot' symbol to failed units and shifting output by 2
spaces.