### PR TITLE
Use last element returned from is-enabled for enabled state

### DIFF
--- a/helm-systemd.el
+++ b/helm-systemd.el
@@ -190,13 +190,14 @@
                      (if loaded
                          (let* ((isenabled
                                  (car
-                                  (split-string
-                                   (shell-command-to-string
-                                    (helm-systemd-concatspace `("systemctl" "is-enabled "
-                                                                ,(if (string-match "User"
-                                                                                   (cdr (assoc 'name source)))
-                                                                     "--user")
-                                                                "--" ,unit))))))
+                                  (last
+                                   (split-string
+                                    (shell-command-to-string
+                                     (helm-systemd-concatspace `("systemctl" "is-enabled "
+                                                                 ,(if (string-match "User"
+                                                                                    (cdr (assoc 'name source)))
+                                                                      "--user")
+                                                                 "--" ,unit)))))))
                                 (propena (cond ((string= isenabled "enabled") 'helm-bookmark-info)
                                                ((string= isenabled "static") 'helm-bookmark-gnus)
                                                (t 'helm-bookmark-gnus)))


### PR DESCRIPTION
otherwise fails for non-native services that output e.g.

$ systemctl is-enabled -- grub-common.service
grub-common.service is not a native service, redirecting to systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install is-enabled grub-common
enabled